### PR TITLE
#165404698 implement user can view account details endpoint

### DIFF
--- a/server/routes/accountRouter.js
+++ b/server/routes/accountRouter.js
@@ -11,4 +11,6 @@ router.patch('/:accountNumber', inputValidator.accountStatus, authenticateUser.v
 
 router.delete('/:accountNumber', authenticateUser.verifyAdmin, accountController.deleteAccount);
 
+router.get('/:accountNumber', authenticateUser.verifyUser, accountController.viewAccount);
+
 export default router;


### PR DESCRIPTION
#### What does this PR do?
This PR creates an endpoint for User to view account details

#### Description of Task to be completed?
The client user can view account details which are stored in a persistent database

Have the following endpoints working
POST /api/v1/auth/signin
 GET /accounts/<account-number>

#### How should this be manually tested?
Clone the repo and cd into the directory
Run npm install
Run npm run Start-dev
Use postman to test all endpoints above
key: Content-Type value: application/json
To test user authentication, get Token from signin endpoint
key: Authorization value: jwt TOKEN
Signin as client user 

#### What are the relevant pivotal tracker stories?
#165404698

![Screenshot (202)](https://user-images.githubusercontent.com/43539944/56730208-3b828e80-674f-11e9-8293-3c5fb984e94c.png)